### PR TITLE
Updated ldapSlashes() method of adLDAPUtils

### DIFF
--- a/lib/adLDAP/classes/adLDAPUtils.php
+++ b/lib/adLDAP/classes/adLDAPUtils.php
@@ -102,8 +102,10 @@ class adLDAPUtils {
     * @return string
     */
     public function ldapSlashes($str){
-        return preg_replace('/([\x00-\x1F\*\(\)\\\\])/e',
-                            '"\\\\\".join("",unpack("H2","$1"))',
+        return preg_replace_callback('/([\x00-\x1F\*\(\)\\\\])/',
+                            function ($m) {
+                                return "\\".join("", unpack("H2", $m[1]))   
+                            },
                             $str);
     }
     


### PR DESCRIPTION
Replaced `preg_replace` with `preg_replace_callback` to prevent use of deprecated modifier.

See [here](https://php.net/manual/en/function.preg-replace.php#refsect1-function.preg-replace-changelog) and [here](https://php.net/manual/en/reference.pcre.pattern.modifiers.php#reference.pcre.pattern.modifiers.eval) for more details.
